### PR TITLE
Supplying the #43 issue for list processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,63 +21,63 @@ go get github.com/gofn/gofn
 package main
 
 import (
-	"context"
-	"flag"
-	"fmt"
-	"log"
-	"runtime"
-	"sync"
+    "context"
+    "flag"
+    "fmt"
+    "log"
+    "runtime"
+    "sync"
 
-	"github.com/gofn/gofn"
-	"github.com/gofn/gofn/iaas/digitalocean"
-	"github.com/gofn/gofn/provision"
+    "github.com/gofn/gofn"
+    "github.com/gofn/gofn/iaas/digitalocean"
+    "github.com/gofn/gofn/provision"
 )
 
 func main() {
-	wait := &sync.WaitGroup{}
-	contextDir := flag.String("contextDir", "./", "a string")
-	dockerfile := flag.String("dockerfile", "Dockerfile", "a string")
-	imageName := flag.String("imageName", "", "a string")
-	remoteBuildURI := flag.String("remoteBuildURI", "", "a string")
-	volumeSource := flag.String("volumeSource", "", "a string")
-	volumeDestination := flag.String("volumeDestination", "", "a string")
-	remoteBuild := flag.Bool("remoteBuild", false, "true or false")
-	input := flag.String("input", "", "a string")
-	flag.Parse()
-	parallels := runtime.GOMAXPROCS(-1) // use max allowed CPUs to parallelize
-	wait.Add(parallels)
-	for i := 0; i < parallels; i++ {
-		go run(*contextDir, *dockerfile, *imageName, *remoteBuildURI, *volumeSource, *volumeDestination, wait, *remoteBuild, *input)
-	}
-	wait.Wait()
+    wait := &sync.WaitGroup{}
+    contextDir := flag.String("contextDir", "./", "a string")
+    dockerfile := flag.String("dockerfile", "Dockerfile", "a string")
+    imageName := flag.String("imageName", "", "a string")
+    remoteBuildURI := flag.String("remoteBuildURI", "", "a string")
+    volumeSource := flag.String("volumeSource", "", "a string")
+    volumeDestination := flag.String("volumeDestination", "", "a string")
+    remoteBuild := flag.Bool("remoteBuild", false, "true or false")
+    input := flag.String("input", "", "a string")
+    flag.Parse()
+    parallels := runtime.GOMAXPROCS(-1) // use max allowed CPUs to parallelize
+    wait.Add(parallels)
+    for i := 0; i < parallels; i++ {
+        go run(*contextDir, *dockerfile, *imageName, *remoteBuildURI, *volumeSource, *volumeDestination, wait, *remoteBuild, *input)
+    }
+    wait.Wait()
 }
 
 func run(contextDir, dockerfile, imageName, remoteBuildURI, volumeSource, volumeDestination string, wait *sync.WaitGroup, remote bool, input string) {
-	buildOpts := &provision.BuildOptions{
-		ContextDir: contextDir,
-		Dockerfile: dockerfile,
-		ImageName:  imageName,
-		RemoteURI:  remoteBuildURI,
-		StdIN:      input,
-	}
-	containerOpts := &provision.ContainerOptions{}
-	if volumeSource != "" {
-		if volumeDestination == "" {
-			volumeDestination = volumeSource
-		}
-		containerOpts.Volumes = []string{fmt.Sprintf("%s:%s", volumeSource, volumeDestination)}
-	}
-	if remote {
-		buildOpts.Iaas = &digitalocean.Digitalocean{}
-	}
+    buildOpts := &provision.BuildOptions{
+        ContextDir: contextDir,
+        Dockerfile: dockerfile,
+        ImageName:  imageName,
+        RemoteURI:  remoteBuildURI,
+        StdIN:      input,
+    }
+    containerOpts := &provision.ContainerOptions{}
+    if volumeSource != "" {
+        if volumeDestination == "" {
+            volumeDestination = volumeSource
+        }
+        containerOpts.Volumes = []string{fmt.Sprintf("%s:%s", volumeSource, volumeDestination)}
+    }
+    if remote {
+        buildOpts.Iaas = &digitalocean.Digitalocean{}
+    }
 
-	defer wait.Done()
-	stdout, stderr, err := gofn.Run(context.Background(), buildOpts, containerOpts)
-	if err != nil {
-		log.Println(err)
-	}
-	fmt.Println("Stderr: ", stderr)
-	fmt.Println("Stdout: ", stdout)
+    defer wait.Done()
+    stdout, stderr, err := gofn.Run(context.Background(), buildOpts, containerOpts)
+    if err != nil {
+        log.Println(err)
+    }
+    fmt.Println("Stderr: ", stderr)
+    fmt.Println("Stdout: ", stdout)
 }
 ```
 
@@ -106,24 +106,24 @@ You can also compile with _go build_ or build and install with _go install_ comm
 
 ### Example Parameters
 
-- -contextDir is the root directory where the Dockerfile, scripts, and other container dependencies are, by default current directory "./".
+* -contextDir is the root directory where the Dockerfile, scripts, and other container dependencies are, by default current directory "./".
 
-- -imageName is the name of the image you want to start, if it does not exist it will be automatically generated and if it exists the system will just start the container.
+* -imageName is the name of the image you want to start, if it does not exist it will be automatically generated and if it exists the system will just start the container.
 
-- -dockerFile is the name of the file containing the container settings, by default Dockerfile
+* -dockerFile is the name of the file containing the container settings, by default Dockerfile
 
-- -volumeSource is the directory that will be mounted as a data volume. By default is empty string indicating his not used.
+* -volumeSource is the directory that will be mounted as a data volume. By default is empty string indicating his not used.
 
-- -volumeDestination is the path mounted inside the container. By default is empty string indicating his  not used but if only omitted, volumeSource is used.
+* -volumeDestination is the path mounted inside the container. By default is empty string indicating his not used but if only omitted, volumeSource is used.
 
-- -remoteBuildURI is remote URI containing the Dockerfile to build.By default is empty.
-More details on [docker api docs](https://docs.docker.com/engine/reference/commandline/build/#/git-repositories)
+* -remoteBuildURI is remote URI containing the Dockerfile to build.By default is empty.
+  More details on [docker api docs](https://docs.docker.com/engine/reference/commandline/build/#/git-repositories)
 
-- remoteBuild is a boolean that indicates if have to run localally or in a machine in digital ocean
-Don't forget to export your api key.
+* remoteBuild is a boolean that indicates if have to run localally or in a machine in digital ocean
+  Don't forget to export your api key.
 
-- -input is a string that will be written to the stdin of the container
+* -input is a string that will be written to the stdin of the container
 
-- -h Shows the list of parameters
+* -h Shows the list of parameters
 
 gofn generates the images with "gofn/" as a prefix.

--- a/provision/docker.go
+++ b/provision/docker.go
@@ -247,3 +247,23 @@ func FnWaitContainer(client *docker.Client, containerID string) chan error {
 	}()
 	return errs
 }
+
+// FnListContainers lists all the containers created by the gofn.
+// It returns the APIContainers from the API, but have to be formatted for pretty printing
+func FnListContainers(client *docker.Client) (containers []docker.APIContainers, err error) {
+	hostContainers, err := client.ListContainers(docker.ListContainersOptions{
+		All: true,
+	})
+
+	if err != nil {
+		containers = nil
+		return
+	}
+
+	for _, container := range hostContainers {
+		if strings.HasPrefix(container.Image, "gofn/") {
+			containers = append(containers, container)
+		}
+	}
+	return
+}

--- a/provision/docker_test.go
+++ b/provision/docker_test.go
@@ -303,6 +303,35 @@ func TestFnFindContainerByIDContainerNotFound(t *testing.T) {
 	}
 }
 
+func TestFnListContainers(t *testing.T) {
+	// Create a new server
+	server := createFakeDockerAPI(t)
+	defer server.Stop()
+
+	// Instanciate the client
+	client := NewTestClient(server.URL(), t)
+
+	imageName := createFakeImage(client)
+
+	container, err := FnContainer(client, ContainerOptions{Image: imageName})
+
+	if err != nil {
+		t.Fatalf("Expect to create an container but failed because %s", err)
+	}
+
+	runFakeContainer(client, container.ID, t)
+
+	containersList, err := FnListContainers(client)
+
+	if err != nil {
+		t.Fatalf("Error testing FnListContainers, error: %s", err)
+	}
+
+	if len(containersList) == 0 {
+		t.Fatal("Expected FnListContainers to have more than zero listed.")
+	}
+}
+
 func TestFnFindContainerByIDServerError(t *testing.T) {
 	client := NewTestClient("wrong", t)
 


### PR DESCRIPTION
I've write a new function called FnListContainers who will list all the containers, running or not created by the `gofn` tool, following the default prefix of the tool, who create images with the `gofn/` prefix. I think suppling in the main library (here) the issue #43, but still be missing the command, I will add to the cli repo soon :smile: 